### PR TITLE
assign the correct path to the filehandle when reading the minified file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Plack-App-MCCS
 
 {{$NEXT}}
+	- Bugfix: assign the correct path to the filehandle when reading the
+	  minified file. This also allows windows tests to pass.
 
 0.007002  2015-09-15 16:39:09+03:00 Asia/Jerusalem
 	- Bugfix: bin/mccs did not parse the root directory from the command

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Plack-App-MCCS
 {{$NEXT}}
 	- Bugfix: assign the correct path to the filehandle when reading the
 	  minified file. This also allows windows tests to pass.
+	- add autodie to protect against ignored errors in file operations
 
 0.007002  2015-09-15 16:39:09+03:00 Asia/Jerusalem
 	- Bugfix: bin/mccs did not parse the root directory from the command

--- a/lib/Plack/App/MCCS.pm
+++ b/lib/Plack/App/MCCS.pm
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 use parent qw/Plack::Component/;
 
+use autodie;
 use Cwd ();
 use Fcntl qw/:flock/;
 use File::Spec::Unix;
@@ -444,7 +445,6 @@ sub call {
 
 				# read the file's contents into $css
 				my $body; Plack::Util::foreach($ifh, sub { $body .= $_[0] });
-				close $ifh;
 
 				# minify contents
 				my $min = $content_type eq 'text/css' ? CSS::Minifier::XS::minify($body) : JavaScript::Minifier::XS::minify($body);

--- a/lib/Plack/App/MCCS.pm
+++ b/lib/Plack/App/MCCS.pm
@@ -440,7 +440,7 @@ sub call {
 					|| return $self->return_403;
 
 				# add ->path attribute to the file handle
-				Plack::Util::set_io_path($ifh, Cwd::realpath($file));
+				Plack::Util::set_io_path($ifh, Cwd::realpath($orig));
 
 				# read the file's contents into $css
 				my $body; Plack::Util::foreach($ifh, sub { $body .= $_[0] });

--- a/t/01-app.t
+++ b/t/01-app.t
@@ -7,6 +7,7 @@ use Plack::App::MCCS;
 use HTTP::Request;
 use HTTP::Date;
 use Data::Dumper;
+use autodie;
 
 my $app = Plack::App::MCCS->new(
 	root => 't/rootdir',


### PR DESCRIPTION
This also allows windows tests to pass.

The windows failures were caused by Cwd complaining correctly about a path being passed to `realpath` not actually pointing to an existent file. That is because the wrong path was actually being passed to it, which is the PATH_INFO data, instead of the concatenated root+PATH_INFO path.

On other OSes this only passed because Cwd ignored the mistaken path there.