### PR TITLE
add min_cache_dir to reduce pollution with files that are hard to filter

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history for Plack-App-MCCS
 	- Bugfix: assign the correct path to the filehandle when reading the
 	  minified file. This also allows windows tests to pass.
 	- add autodie to protect against ignored errors in file operations
+	- add min_cache_dir to reduce pollution with files that are hard to
+	  filter
 
 0.007002  2015-09-15 16:39:09+03:00 Asia/Jerusalem
 	- Bugfix: bin/mccs did not parse the root directory from the command

--- a/t/rootdir/dir/subdir/script.js
+++ b/t/rootdir/dir/subdir/script.js
@@ -1,0 +1,10 @@
+$(document).ready(function() {
+	var name = $('#name').val();
+	var password = $('#password').val();
+
+	showSomething(name, password);
+});
+
+function showSomething(name, password) {
+	alert("Hi "+name+", your password is "+password+" and I am going to broadcast it to the entire world.");
+}


### PR DESCRIPTION
This PR bases itself on #2, so until that one's merged this one will contain the two extra commits as well. Please ignore those until #2 is dealt with.

I have the issue that our deployment is self-validating in terms of what files it expects to be there and not be there. The files for etag and gz are easy enough to filter. However since we have a mix of unminified and minified files i can't simply have it ignore *.min.* as generated files and would have to list them all manually.

With this option any files generated by minifying are stored in the specified cache dir within the root dir, which can then be excluded wholesale.

Not entirely sure if this one is up to snuff, but please consider it and let me know if you'd be willing to integrate it.